### PR TITLE
Documentation changes for using Webhook Relay instead of Port Forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This plugin provides 3 options for use in HomeKit<br>Both option have additional
 
 You can acquire your API key from Rachio io.app [documented here](https://rachio.readme.io/docs/authentication).
 
-## Note on Webhooks
+## Notes on Webhooks
 
 `homebridge-rachio-irrigation` **requires** webhooks to update Homekit accessory status in real time such as a defined schedule from the Rachio app.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You can acquire your API key from Rachio io.app [documented here](https://rachio
    - Create a new "New Basic Forwarding" from the quickstart on the Dashboard.
    - Select _Use Default Input Domain_. Then Continue.
    - For _Destination URL_ enter: `http://127.0.0.1:27546/`
-     - If you'll be installing the relay on a computer different from your Homebridge, replace the `127.0.0.1` with the ip or network name of your Homebridge server.
+     - If you'll be installing the relay on a computer different from your Homebridge, replace the `127.0.0.1` with the IP or network name of your Homebridge server.
    - For _Output type_ choose: _Internal_
    - For _Lock destination path_ disable it so it says: _not locked_
    - Hit Continue so you're on the review step. Change your _Configuration name_ to something that makes sense for you.  I set mine to: `rachio-config`
@@ -57,16 +57,15 @@ You can acquire your API key from Rachio io.app [documented here](https://rachio
      - Copy the `Key`, `Secret`, and `relay CLI command` somewhere.  You'll need them later.
  - Now you'll need to install their Relay software on a computer on your network (probably wherever you have Homebridge installed). Install instructions can be [found here](https://docs.webhookrelay.com/installation-options/installation-options/install-cli).
  - Edit Settings for `homebridge-rachio-irrigation` to use the Webhook Relay
-   - When setting up this plugin and you get to the _External IP Address_ section, just enter `127.0.0.1`. The field only accepts IP addresses, so you'll need to change it later manually in the config.json file.
+   - When setting up this plugin and you get to the _External IP Address or Domain_ section, enter the _default public endpoint_ that Webhook Relay provides you with.  It'll look like `somethinglongandrandom.hooks.webhookrelay.com`. You can find it at _Request Forwarding > Buckets_ listed under _Default public endpoint_ in the Webhook Relay dashboard.
    - Set the _External Webhook Port_ to: `80`
    - The _Internal Webhook Port_ can be left to the default `27546`. If you change it, be sure to change the _Destination URL_ in the Webhook Relay bucket settings you configured earlier.
-   - After saving the settings, go to the Config tab in Homebridge UI, and scroll down to find the section for this plugin.  You're going to change only one item, and that's `external_IP_address` where it says `127.0.0.1` to the URL that the webhook Relay service gave you.  It'll look like `somethinglongandrandom.hooks.webhookrelay.com`. You can find it at _Request Forwarding > Buckets_ listed under _Default public endpoint_ in the Webhook Relay dashboard.
-    - Save the Config changes in the top right, and restart Homebridge
+   - Save the Config changes, and then restart Homebridge
  - Test it!
    - Make sure you're running the relay service, in Terminal or the command line, it'll look something like this: `relay forward -b rachio-config`
+     - `rachio-config` should be the name of your bucket.
    - Go to `http://somethinglongandrandom.hooks.webhookrelay.com/test` in your browser and a moment later you should see in the Homebridge logs that the test was successful.
  - After you have tested everything works ok, you can make the Webhook Relay software always run by using the [instructions here](https://docs.webhookrelay.com/installation-options/installation-options/background-service).
-
 
 The startup log will show if the configuration is correct and working.
 


### PR DESCRIPTION
I didn't want to use port forwarding, and while using Webhook Relay adds a number of steps, it has the benefit of not needing to poke a hole in my local firewall, and it works if your IP address gets changed from your ISP.

This pull request @valiquette just edits the documentation to explain how to do this.