### PR TITLE
fix(homebridge-rachio): prevent crash from undefined `response` variable

### DIFF
--- a/rachioplatform.js
+++ b/rachioplatform.js
@@ -677,7 +677,7 @@ class RachioPlatform {
 																.setCharacteristic(Characteristic.StatusLowBattery, Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW)
 																.setCharacteristic(Characteristic.ChargingState, Characteristic.ChargingState.NOT_CHARGEABLE)
 																.setCharacteristic(Characteristic.BatteryLevel, 10);
-															this.log.warn('Replace batteries for %s soon', response.data.valve.name)
+															this.log.warn('Replace batteries for %s soon', valve.name)
 															break
 										}
 									} else {


### PR DESCRIPTION
## Summary

Fixes a runtime error triggered when a Rachio wireless valve reports a critically low battery state.

Rachio valves return `"REPLACE"` as the battery status when the batteries are depleted. In this code path, the plugin incorrectly references a `response` object instead of the current valve object being processed, causing Homebridge to crash with:

```text id="nykq5u"
ReferenceError: response is not defined
    at /var/lib/homebridge/node_modules/homebridge-rachio-irrigation/rachioplatform.js:680:63
    at Array.forEach (<anonymous>)
    at /var/lib/homebridge/node_modules/homebridge-rachio-irrigation/rachioplatform.js:615:25
    at processTicksAndRejections (node:internal/process/task_queues:104:5)
```

This PR updates the battery status handling logic to reference the correct valve object, allowing low-battery valves to be processed correctly without interrupting platform initialization.

## Root Cause

During valve processing, the code handling battery status values references `response.batteryStatus` even though `response` does not exist in that scope.

The issue is triggered when the Rachio API returns `"REPLACE"` as the battery status for a valve, causing the invalid reference to execute and the plugin to fail during accessory initialization.
